### PR TITLE
Add UniformMatrix4fv, DrawArrays, ValidateProgram, GetError to OpenGL 2.1 backend.

### DIFF
--- a/webgl_gl2.go
+++ b/webgl_gl2.go
@@ -680,6 +680,10 @@ func (c *Context) GetUniformLocation(program *Program, name string) *UniformLoca
 	return &UniformLocation{gl.GetUniformLocation(program.uint32, gl.Str(name+"\x00"))}
 }
 
+func (c *Context) GetError() int {
+	return int(gl.GetError())
+}
+
 func (c *Context) CreateBuffer() *Buffer {
 	var loc uint32
 	gl.GenBuffers(1, &loc)
@@ -715,12 +719,28 @@ func (c *Context) BlendFunc(src, dst int) {
 	gl.BlendFunc(uint32(src), uint32(dst))
 }
 
+func (c *Context) UniformMatrix4fv(location *UniformLocation, transpose bool, value []float32) {
+	// TODO: count value of 1 is currently hardcoded.
+	//       Perhaps it should be len(value) / 16 or something else?
+	//       In OpenGL 2.1 it is a manually supplied parameter, but WebGL does not have it.
+	//       Not sure if WebGL automatically deduces it and supports count values greater than 1, or if 1 is always assumed.
+	gl.UniformMatrix4fv(location.int32, 1, transpose, &value[0])
+}
+
 func (c *Context) UseProgram(program *Program) {
 	if program == nil {
 		gl.UseProgram(0)
 		return
 	}
 	gl.UseProgram(program.uint32)
+}
+
+func (c *Context) ValidateProgram(program *Program) {
+	if program == nil {
+		gl.ValidateProgram(0)
+		return
+	}
+	gl.ValidateProgram(program.uint32)
 }
 
 func (c *Context) Uniform2f(location *UniformLocation, x, y float32) {
@@ -730,6 +750,10 @@ func (c *Context) Uniform2f(location *UniformLocation, x, y float32) {
 func (c *Context) BufferSubData(target int, offset int, data interface{}) {
 	size := uintptr(reflect.ValueOf(data).Len()) * reflect.TypeOf(data).Elem().Size()
 	gl.BufferSubData(uint32(target), offset, int(size), gl.Ptr(data))
+}
+
+func (c *Context) DrawArrays(mode, first, count int) {
+	gl.DrawArrays(uint32(mode), int32(first), int32(count))
 }
 
 func (c *Context) DrawElements(mode, count, typ, offset int) {


### PR DESCRIPTION
- Use count value of 1 for gl.UniformMatrix4fv.

This is needed for https://github.com/shurcooL/play/commit/6398c5aa60a530d12de8b8616c649ff88161c45a to work correctly. I added the missing OpenGL 2.1 backend funcs that I needed.

Joseph, I have three comments about this package:
1. I see this is currently a fork of `github.com/gopherjs/webgl`, which is a set of pure bindings for WebGL. This package, by now, is a higher level package that exposes a unified API with 2 backends: WebGL and OpenGL 2.1.
   
   Based on the current README, it seems that this is an experimental attempt to eventually merge into the `github.com/gopherjs/webgl` package. I think it might make sense not do that, but instead have a package that is a pure binding for WebGL, and this package that has a unified API for WebGL and OpenGL 2.1.
   
   There are many reasons. Someone might want to just use the pure WebGL API and not bother with anything else. They might not want any compromises that might have to be done for this unified version. Also, this one targets OpenGL 2.1, but another version could target WebGL and non-2.1.
   
   I'm planning to try (experimentally) a similar package that exposes a unified API for glfw package. It will also have two backends, glfw for desktop, and html/canvas/etc. backend for browsers. It will import glfw and reuse it, rather than trying to become a part of glfw.
2. Related to above, if you agree to keep this package separate from pure WebGL bindings, I think a different name is better. I would suggest `gogl`. I an planning to name my glfw unified package `goglfw`.
   - [ ] Also, you'd need to enable issues on this repo.
3. Would you like to add me as a collaborator to this repo? I can make PRs and avoid pushing to master if you wish, or I can push to master since this package is quite immature and experimental. Or I can fork it and work on my version (where you're welcome to have push rights hehe).
